### PR TITLE
SID renamed to JSNODESID and JSNODESID magic GET parameter allowed for non-cookie version

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -1,7 +1,7 @@
 /* session.js - sessions module for node.js
 
-   Core Sesssion Logic : 
-     inimino@inimino.org 
+   Core Sesssion Logic :
+     inimino@inimino.org
      2009-12-01
      MIT License
 
@@ -108,11 +108,20 @@ function cleanup(){var id,now,next
     timeout=setTimeout(cleanup,next - (+new Date) + 1000)}
 
 function idFromRequest(req,opts){var m
-  // look for an existing SID in the Cookie header for which we have a session
+  // look for an existing JSNODESID in the Cookie header for which we have a session
   if(req.headers.cookie
-  && (m = /SID=([^ ,;]*)/.exec(req.headers.cookie))
+  && (m = /JSNODESID=([^ ,;]*)/.exec(req.headers.cookie))
   && ownProp(sessions,m[1])){
     return m[1]}
+
+  //otherwise we search the GET-params
+  var params = require('url').parse(req.url, true).query || {};
+  if (params.JSNODESID) {
+	return params.JSNODESID;
+  }
+
+  //FIXME:
+  // RESTful: /SESSION_ID/
 
   // otherwise we need to create one
   // if an ID is provided by the caller in the options, we use that
@@ -149,7 +158,7 @@ function randomString(bits){var chars,rand,i,ret
   return ret}
 
 Session.prototype.getSetCookieHeaderValue=function(){var parts
-  parts=['SID='+this.id]
+  parts=['JSNODESID='+this.id]
   if(this.path) parts.push('path='+this.path)
   if(this.domain) parts.push('domain='+this.domain)
   if(this.persistent) parts.push('expires='+dateCookieString(this.expiration))


### PR DESCRIPTION
As of #coh516 who posted the issue with the too generic SID session variable, i fixed this the way he suggested.

In addition, I added the possibility to add ?JSNODESID=[session id] as query string to pass the session ID via GET for a non-cookie version.
